### PR TITLE
AGENTES - Mostrar feriados antiguos

### DIFF
--- a/modules/ausentismo/controller/feriado.ts
+++ b/modules/ausentismo/controller/feriado.ts
@@ -25,7 +25,8 @@ class FeriadoController extends BaseController {
             // recupera la info en un periodo de un anio hacia atras y adelante
             const thisYear = (new Date()).getFullYear();
             const fechaHasta = new Date((thisYear + 1) + "-12-31");
-            const fechaDesde = new Date((thisYear - 1) + "-01-01") ;
+            //Se cambia para que muestre desde el primer feriado registrado.
+            const fechaDesde = new Date((2000) + "-01-01") ;
             const pipeline = [
                 { $match: { fecha: { $gte:fechaDesde, $lte:fechaHasta }}},
                 { $project:


### PR DESCRIPTION
Se muestran los feriados desde el año 2000. Porque es el primero que está registrado.
Ver módulo Configuración -> Feriados.